### PR TITLE
Use safe signer seperator which doesn't error with Django 1.10

### DIFF
--- a/django_yadt/fields.py
+++ b/django_yadt/fields.py
@@ -365,7 +365,7 @@ class HMACYADTImageField(YADTImageField):
     def __init__(self, salt='django_yadt.fields.HMACYADTImageField', *args, **kwargs):
         kwargs['filename_prefix'] = lambda x: Signer(
             salt=salt,
-            sep='_',
+            sep='.',
         ).sign(x.pk)
 
         super(HMACYADTImageField, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Breaking change.

Using `_` as the seperator [errors with Django 1.10](https://github.com/django/django/commit/e6cfa08f2d478cb962528188dff5cf4daf5e5f9b). We were patching the `Signer` in styleme, so although we have been past Django 1.10 for many years, it's only erroring now after switching back to the non-patched version.

