### PR TITLE
Introduce DJANGO_YADT_CACHEBUST_PARAMETER_KEY and make querystring consistent

### DIFF
--- a/django_yadt/app_settings.py
+++ b/django_yadt/app_settings.py
@@ -1,0 +1,7 @@
+from django.conf import settings
+
+DJANGO_YADT_CACHEBUST_QUERY_PARAMETER_KEY = getattr(
+    settings,
+    'DJANGO_YADT_CACHEBUST_QUERY_PARAMETER_KEY',
+    '_',
+)

--- a/django_yadt/fields.py
+++ b/django_yadt/fields.py
@@ -9,6 +9,7 @@ from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.core.signing import Signer
 
+from .app_settings import DJANGO_YADT_CACHEBUST_QUERY_PARAMETER_KEY
 from .utils import from_dotted_path
 
 IMAGE_VARIANTS = []
@@ -236,11 +237,10 @@ class YADTImageFile(object):
             )
 
             if suffix:
-                # If URL already has a querystring, append an anonymous param.
                 if '?' in url:
-                    url += '&_=%s' % suffix
+                    url += '&%s=%s' % (DJANGO_YADT_CACHEBUST_QUERY_PARAMETER_KEY, suffix)
                 else:
-                    url += '?%s' % suffix
+                    url += '?%s=%s' % (DJANGO_YADT_CACHEBUST_QUERY_PARAMETER_KEY, suffix)
 
         return url
 


### PR DESCRIPTION
Breaking change.

- Always append a query parameter with a key
- Allow setting the query parameter key used with settings