### PR TITLE
Support Pillow 10+

### DIFF
--- a/django_yadt/processors.py
+++ b/django_yadt/processors.py
@@ -1,5 +1,12 @@
 from PIL import Image, ImageDraw
 
+try:
+    # Deprecated in Pillow 9.1.0, removed in 10
+    ANTIALIAS = Image.Resampling.LANCZOS
+except AttributeError:
+    ANTIALIAS = Image.ANTIALIAS
+
+
 def crop(im, config):
     """
     Resize and crop to the specified dimensions, regardless of source size.
@@ -30,7 +37,7 @@ def crop(im, config):
 
     return im.resize(
         (config['width'], config['height']),
-        Image.ANTIALIAS,
+        ANTIALIAS,
     )
 
 def thumbnail(im, config):
@@ -40,7 +47,7 @@ def thumbnail(im, config):
 
     im.thumbnail(
         (config['width'], config['height']),
-        Image.ANTIALIAS,
+        ANTIALIAS,
     )
 
     return im
@@ -56,7 +63,7 @@ def circle(im, config):
     # Create circular mask
     mask = Image.new('L', mask_size, 0)
     ImageDraw.Draw(mask).ellipse((0, 0) + mask_size, fill=255)
-    mask.thumbnail(im.size, Image.ANTIALIAS)
+    mask.thumbnail(im.size, ANTIALIAS)
 
     # Need a new white background to paste it on
     existing = im

--- a/django_yadt/processors.py
+++ b/django_yadt/processors.py
@@ -1,9 +1,9 @@
 from PIL import Image, ImageDraw
 
 try:
-    # Deprecated in Pillow 9.1.0, removed in 10
     ANTIALIAS = Image.Resampling.LANCZOS
 except AttributeError:
+    # Deprecated in Pillow 9.1.0, removed in 10
     ANTIALIAS = Image.ANTIALIAS
 
 


### PR DESCRIPTION
[Pillow 9.1.0 deprecated](https://pillow.readthedocs.io/en/stable/releasenotes/9.1.0.html#deprecations) some module-level constants in favour of Python 3 style enums. This commit introduces support for those enum values, while still falling back to supporting older Pillow for now as the legacy names are [removed in Pillow 10](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#constants).

Tested by running the tests of our main codebase with this patch applied on top and with Pillow 10 installed.